### PR TITLE
Fix typos

### DIFF
--- a/rules/timestampexpanded/timestampexpanded.go
+++ b/rules/timestampexpanded/timestampexpanded.go
@@ -23,7 +23,7 @@ type Timestampexpanded struct {
 }
 
 var (
-	vT = "Variable %q possibly contains and timestamp and should be simply exapnded."
+	vT = "Variable %q possibly contains a timestamp and should be simply expanded."
 )
 
 // Name returns the name of the rule


### PR DESCRIPTION
There are two typos in the timestampexpanded rule.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [X] CI passes
- [X] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change