### PR TITLE
Docker-based build environment (to build checkmake binary)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,19 @@ VERSION := $(shell git describe --tags --always --dirty)
 GOVERSION := $(shell go version)
 BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILDDATE := $(shell date -u +"%B %d, %Y")
-BUILDER := $(shell echo "`git config user.name` <`git config user.email`>")
+
+NAME := $(if $(BUILDER_NAME),$(BUILDER_NAME),$(shell git config user.name))
+ifndef NAME
+$(error "You must set environment variable BUILDER_NAME or set a user.name in your git configuration.")
+endif
+
+EMAIL := $(if $(BUILDER_EMAIL),$(BUILDER_EMAIL),$(shell git config user.email))
+ifndef EMAIL
+$(error "You must set environment variable BUILDER_EMAIL or set a user.email in your git configuration.")
+endif
+
+BUILDER := $(shell echo "${NAME} <${EMAIL}>")
+
 PKG_RELEASE ?= 1
 PROJECT_URL := "https://github.com/mrtazz/$(NAME)"
 LDFLAGS := -X 'main.version=$(VERSION)' \

--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -1,0 +1,2 @@
+FROM golang:1.13.8
+RUN apt-get update && apt-get install -y pandoc

--- a/buildenv/README.md
+++ b/buildenv/README.md
@@ -1,0 +1,36 @@
+# Build Environment
+We have a docker-based build environment which helps you to build the checkmake binary on a system that has no golang, etc. installed.
+
+# Generate Build Environment
+Run:
+```
+cd buildenv
+docker build -t checkmake/buildenv:latest .
+cd ..
+```
+to generate a build environment (docker image). This docker images can be used to build your checkmake binary. 
+
+# Build Checkmake Binary
+Run 
+```
+docker run --rm -v $(pwd):/data --workdir /data checkmake/buildenv:latest make
+```
+to generate the checkmake binary.
+Output is similar to:
+```
+Checking the programs required for the build are installed...
+install -d .d
+echo "checkmake: $(go list -f '{{ join .Deps "\n" }}' cmd/checkmake/main.go | awk '/github/ { gsub(/^github.com\/[a-z]*\/[a-z]*\//, ""); printf $0"/*.go " }')" > .d/checkmake.d
+go build -ldflags "-X 'main.version=0.1.0-22-g42f1561' -X 'main.buildTime=2020-02-23T16:02:51Z' -X 'main.builder= <>' -X 'main.goversion=go version go1.13.8 linux/amd64'" -o checkmake cmd/checkmake/main.go
+sed "s/REPLACE_DATE/February 23, 2020/" man/man1/checkmake.1.md | pandoc -s -t man -o checkmake.1
+```
+
+# Test Checkmake Binary
+Run checkmake binary:
+```
+./checkmake --version
+```
+to test the binary. Output should be similar to:
+```
+checkmake 0.1.0-22-g42f1561 built at 2020-02-23T16:02:51Z by  <> with go version go1.13.8 linux/amd64
+```

--- a/buildenv/README.md
+++ b/buildenv/README.md
@@ -13,9 +13,17 @@ to generate a build environment (docker image). This docker images can be used t
 # Build Checkmake Binary
 Run 
 ```
-docker run --rm -v $(pwd):/data --workdir /data checkmake/buildenv:latest make
+docker run --rm -e BUILDER_NAME="Your Name" -e BUILDER_EMAIL="your.name@example.com" -v $(pwd):/data --workdir /data checkmake/buildenv:latest make
 ```
-to generate the checkmake binary.
+to generate the checkmake binary. (Replace "Your name" with your name and "your.name@example.com" with your email address)
+
+An alternative is to define the variables on your host system an then pass it to docker:
+``` 
+export BUILDER_NAME="Your Name"
+export BUILDER_EMAIL="your.name@example.com"
+docker run --rm -e BUILDER_NAME -e BUILDER_EMAIL -v $(pwd):/data --workdir /data checkmake/buildenv:latest make
+```
+
 Output is similar to:
 ```
 Checking the programs required for the build are installed...
@@ -32,5 +40,5 @@ Run checkmake binary:
 ```
 to test the binary. Output should be similar to:
 ```
-checkmake 0.1.0-22-g42f1561 built at 2020-02-23T16:02:51Z by  <> with go version go1.13.8 linux/amd64
+checkmake 0.1.0-22-g42f1561 built at 2020-02-23T16:02:51Z by Your Name <your.name@example.com> with go version go1.13.8 linux/amd64
 ```


### PR DESCRIPTION
In https://github.com/mrtazz/checkmake/issues/28 we learned that is maybe helpful to have a docker-based build environment available for users that are interested in a fresh checkmake binary but still want to keep the host system free from build dependencies.

This PR adds a build environment (docker-based) to the project.

BTW: i hope to see more frequent releases of binary files here: https://github.com/mrtazz/checkmake/releases. 