### PR TITLE
Only print the header if there are violations to display

### DIFF
--- a/cmd/checkmake/main.go
+++ b/cmd/checkmake/main.go
@@ -54,7 +54,9 @@ func main() {
 
 	formatter, violations := parseArgsAndGetFormatter(args)
 
-	formatter.Format(violations)
+	if len(violations) > 0 {
+		formatter.Format(violations)
+	}
 
 	os.Exit(len(violations))
 }

--- a/formatters/default.go
+++ b/formatters/default.go
@@ -21,7 +21,6 @@ func NewDefaultFormatter() *DefaultFormatter {
 
 // Format is the function to call to get the formatted output
 func (f *DefaultFormatter) Format(violations rules.RuleViolationList) {
-
 	data := make([][]string, len(violations))
 
 	for idx, val := range violations {
@@ -37,6 +36,7 @@ func (f *DefaultFormatter) Format(violations rules.RuleViolationList) {
 	table.SetCenterSeparator(" ")
 	table.SetColumnSeparator(" ")
 	table.SetRowSeparator(" ")
+	table.SetBorder(false)
 	table.SetAutoWrapText(true)
 
 	table.AppendBulk(data)


### PR DESCRIPTION
## Checklist

This PR updates the formatter logic to only displays violations if there are any, which for the default formatter results in the headers not being printed and also removes the newlines from start/end of the content. This follows the UNIX philosophy of [no news is good news](https://en.wikipedia.org/wiki/Talk%3AUnix_philosophy#No_news_is_good_news) 🙂

e.g.

**Before**

With violations:

```sh
$ ./checkmake Makefile

      RULE                 DESCRIPTION             LINE NUMBER

  minphony        Missing required phony target    0
                  "all"
  minphony        Missing required phony target    0
                  "clean"
  minphony        Missing required phony target    0
                  "test"
  phonydeclared   Target "all" should be           67
                  declared PHONY.
  phonydeclared   Target "binaries" should be      70
                  declared PHONY.
  phonydeclared   Target "install" should be               103
                  declared PHONY.
  phonydeclared   Target "packages" should be              109
                  declared PHONY.

```

Without violations:

```
$ ./checkmake Makefile

  RULE   DESCRIPTION   LINE NUMBER

$ ./checkmake Makefile | wc -l
       4
```

**After**

With violations:

```sh
$ ./checkmake Makefile
      RULE                 DESCRIPTION             LINE NUMBER

  minphony        Missing required phony target    0
                  "all"
  minphony        Missing required phony target    0
                  "clean"
  minphony        Missing required phony target    0
                  "test"
  phonydeclared   Target "all" should be           67
                  declared PHONY.
  phonydeclared   Target "binaries" should be      70
                  declared PHONY.
  phonydeclared   Target "install" should be               103
                  declared PHONY.
  phonydeclared   Target "packages" should be              109
                  declared PHONY.
```

Without violations:

```sh
$ ./checkmake Makefile
$ ./checkmake Makefile | wc -l
       0
```

- [ ] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
