### PR TITLE
remove newline for custom formatter

### DIFF
--- a/formatters/custom.go
+++ b/formatters/custom.go
@@ -38,7 +38,6 @@ func (f *CustomFormatter) Format(violations rules.RuleViolationList) {
 		if err != nil {
 			logger.Error(err.Error())
 		}
-		io.WriteString(f.out, "\r\n")
 	}
 
 }


### PR DESCRIPTION
## Overview
We've been adding newlines to the custom formatter output for no good reason.
This is breaking some tools that don't expext newlines. And if newlines are
needed they can always be added as part of the passed in custom formatter
template.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [x] Documentation (README, docs/, man pages) is updated
- [x] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change

fixes https://github.com/mrtazz/checkmake/issues/54
