### PR TITLE
Fix Dockerfile to build on podman.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.13 as builder
 
-ARG BUILDER_NAME BUILDER_EMAIL
+ARG BUILDER_NAME
+ARG BUILDER_EMAIL
 
 COPY . /go/src/github.com/mrtazz/checkmake
 


### PR DESCRIPTION
Hello,

This commit fixes the following error on [podman](https://podman.io/) that is used mainly on Fedora, RHEL.

```
$ podman --version
podman version 3.4.4

$ podman build --build-arg BUILDER_NAME='Your Name' --build-arg BUILDER_EMAIL=your.name@example.com -t checkmake .
[1/2] STEP 1/5: FROM golang:1.13 AS builder
[1/2] STEP 2/5: ARG BUILDER_NAME BUILDER_EMAIL
[2/2] STEP 1/5: FROM alpine:3.9
Error: error building at STEP "ARG BUILDER_NAME BUILDER_EMAIL": ARG requires exactly one argument definition
```

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [X] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated. => I think we don't need to update the documents for this PR.
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change => Do you want to add docker/podman build case to CI?
