### PR TITLE
Make it possible to manually set the version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export GOFLAGS = -mod=vendor
 NAME := checkmake
 DESC := experimental linter for Makefiles
 PREFIX ?= usr/local
-VERSION := $(shell git describe --tags --always --dirty)
+VERSION ?= $(shell git describe --tags --always --dirty)
 GOVERSION := $(shell go version)
 BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILDDATE := $(shell date -u +"%B %d, %Y")


### PR DESCRIPTION
Hi, I've added the possibility to manually set the version number via an environment variable, just like how it is already possible to override the prefix, builder name and email address. This useful for building `checkmake` without errors when there is no git repository available, such as when downloading an archive like [this one](https://github.com/mrtazz/checkmake/archive/refs/tags/0.2.1.tar.gz).

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
