### PR TITLE
Add pre commit hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,35 @@
+name: pre-commit
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - '.pre-commit-config.yaml'
+      - '.pre-commit-hooks.yaml'
+      - 'Makefile'
+      - 'makefile'
+      - 'GNUmakefile'
+      - '**.mk'
+  push:
+    paths:
+      - '.pre-commit-config.yaml'
+      - '.pre-commit-hooks.yaml'
+      - 'Makefile'
+      - 'makefile'
+      - 'GNUmakefile'
+      - '**.mk'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - name: Set up Go 1.17
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+      id: go
+    - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,7 @@ on:
       - 'makefile'
       - 'GNUmakefile'
       - '**.mk'
+      - '**.make'
   push:
     paths:
       - '.pre-commit-config.yaml'
@@ -20,6 +21,7 @@ on:
       - 'makefile'
       - 'GNUmakefile'
       - '**.mk'
+      - '**.make'
 
 jobs:
   pre-commit:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,4 +2,4 @@ repos:
 -   repo: https://github.com/mrtazz/checkmake.git
     rev: 0.2.2
     hooks:
-    -   id: checkmake
+    - id: checkmake

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/mrtazz/checkmake.git
+    rev: 0.2.2
+    hooks:
+    -   id: checkmake

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+exclude: |
+    (?x)^(
+        vendor/.*
+    )$
 repos:
 -   repo: https://github.com/mrtazz/checkmake.git
     rev: 0.2.2
@@ -5,5 +9,6 @@ repos:
     - id: checkmake
       exclude: |
         (?x)^(
+          vendor/.*|
           fixtures/missing_phony\.make
         )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/mrtazz/checkmake.git
+-   repo: https://github.com/trinitronx/checkmake.git
     rev: 0.2.2
     hooks:
     -   id: checkmake

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,7 @@ repos:
     rev: 0.2.2
     hooks:
     - id: checkmake
+      exclude: |
+        (?x)^(
+          fixtures/missing_phony\.make
+        )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/trinitronx/checkmake.git
+-   repo: https://github.com/mrtazz/checkmake.git
     rev: 0.2.2
     hooks:
     -   id: checkmake

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: checkmake
+    name: Makefile linter/analyzer
+    entry: checkmake
+    language: golang
+    files: Makefile

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,4 +2,8 @@
     name: Makefile linter/analyzer
     entry: checkmake
     language: golang
-    files: Makefile
+    files: |
+        (?x)^(
+            (GNU)?[Mm]akefile|
+            .*\.mk
+        )$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
     name: Makefile linter/analyzer
     entry: checkmake
     language: golang
+    pass_filenames: true
     files: |
         (?x)^(
             (GNU)?[Mm]akefile|

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,5 +6,6 @@
     files: |
         (?x)^(
             (GNU)?[Mm]akefile|
-            .*\.mk
+            .*\.mk|
+            .*\.make
         )$

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ on:
       - 'makefile'
       - 'GNUmakefile'
       - '**.mk'
+      - '**.make'
   push:
     paths:
       - '.pre-commit-config.yaml'
@@ -99,6 +100,7 @@ on:
       - 'makefile'
       - 'GNUmakefile'
       - '**.mk'
+      - '**.make'
 
 jobs:
   pre-commit:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,66 @@ Then run it with your Makefile attached, below is an example of it assuming the 
 docker run -v "$PWD"/Makefile:/Makefile checker
 ```
 
+## `pre-commit` usage
+
+This repo includes a `pre-commit` hook, which you may choose to use in your own
+repos. Simply add a `.pre-commit-config.yaml` to your repo's top-level directory
+
+```yaml
+repos:
+-   repo: https://github.com/mrtazz/checkmake.git
+    rev: 0.2.2
+    hooks:
+    -   id: checkmake
+```
+
+Then, run `pre-commit` as usual. For example:
+
+```sh
+pre-commit run --all-files
+```
+
+You may also choose to run this as a GitHub Actions workflow. To do this, add a
+`.github/workflows/pre-commit.yml` workflow to your repo:
+
+```yaml
+name: pre-commit
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - '.pre-commit-config.yaml'
+      - '.pre-commit-hooks.yaml'
+      - 'Makefile'
+      - 'makefile'
+      - 'GNUmakefile'
+      - '**.mk'
+  push:
+    paths:
+      - '.pre-commit-config.yaml'
+      - '.pre-commit-hooks.yaml'
+      - 'Makefile'
+      - 'makefile'
+      - 'GNUmakefile'
+      - '**.mk'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - name: Set up Go 1.17
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+      id: go
+    - uses: pre-commit/action@v2.0.3
+```
+
 ## Installation
 
 ### Requirements


### PR DESCRIPTION
## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
  See the [included GitHub Actions workflow on my fork here][1]. It is expected to fail on this repo [until tag `0.2.2` exists][2] (see notes below).
- [x] Description of proposed change:
  Makes this repo a fully-fledged `pre-commit` hook.
  
  Now that Go modules are integrated into new versions of GoLang, the simplest path
  forward for getting this `pre-commit` hook working again is to include it in this repo.
  `pre-commit` hooks with `language: golang` are designed to be included along with the go
  module's github repo project.
  
  Problem that was introduced by new GoLang versions:  Lucas-C/pre-commit-hooks-go#2
  As noted in #19, `go get ./...`, and now `go install ./...` commands
  are based on certain assumptions. With newer versions of GoLang and now
  go modules, there are further assumptions that `go.mod` and `package` strings match
  the repo name, and this does not work for a wrapper repo that tries to include this one
  because it uses `package main`.
  Thus, the original pre-commit hook in #19 is now broken.  I tried a few hack-ish methods of
  wrapping or including this repo as a go module under `additional_dependencies`.
  However, those methods were messy and did not work.
- [x] Documentation (README, docs/, man pages) is updated
  - **NOTE:** This depends on an immutable git tag or sha to be committed to this repo, because `pre-commit` requires any `rev` specified to be immutable.
  The included `.pre-commit-config.yaml` specifies `0.2.2`, under the assumption that
  this tag will exist after this Pull Request is merged.

        repos:
        -   repo: https://github.com/mrtazz/checkmake.git
            rev: 0.2.2
            hooks:
            - id: checkmake

- [x] Existing issue is referenced if there is one:
  - Lucas-C/pre-commit-hooks-go#2
- [x] Unit tests for the proposed change
  - **NOTE:** As noted above, this depends on an immutable git tag `0.2.2` being created on
  this repo after this Pull Request is merged.
  I've run the [included GitHub Actions workflow on my fork here][1], by creating a fork-only local tag: `0.2.2`.  It's passing there, but is expected to fail here until that tag exists.
  
  - **EDIT:** Additionally, I've pushed up another PR #70, which fixes the use case for running against multiple `Makefile`/ `*.mk` / `*.make` file patterns.  I've enabled this feature in  commits 2d14c7a and a12e9a0.
  Without merging #70, the `pre-commit` run will return nonzero exit status and print the usage text for `checkmake`.  This is because previous to #70, it did not support passing multiple filenames on the command line.


[1]: https://github.com/trinitronx/checkmake/runs/6202408279?check_suite_focus=true#step:5:56
[2]: https://github.com/mrtazz/checkmake/pull/69/commits/55397f850f58055d4236fb23ee4e07dfd2919315#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R3