### PR TITLE
Feature/add support for multiple makefiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ not do what you want it to.
 ```
 % checkmake Makefile
 
+% checkmake Makefile foo.mk bar.mk baz.mk
+
 % checkmake --help
 checkmake.
 
 Usage:
-checkmake [--debug|--config=<configPath>] <makefile>
+checkmake [--debug|--config=<configPath>] <makefile>...
 checkmake -h | --help
 checkmake --version
 

--- a/formatters/custom_test.go
+++ b/formatters/custom_test.go
@@ -14,20 +14,20 @@ import (
 func TestCustomFormatter(t *testing.T) {
 	out := new(bytes.Buffer)
 
-	tmpl, _ := template.New("test").Parse("{{.LineNumber}}:{{.Rule}}:{{.Violation}}")
+	tmpl, _ := template.New("test").Parse("{{.FileName}}:{{.LineNumber}}:{{.Rule}}:{{.Violation}}")
 	formatter := CustomFormatter{template: tmpl, out: out}
 
 	makefile, _ := parser.Parse("../fixtures/missing_phony.make")
 
 	violations := validator.Validate(makefile, &config.Config{})
 	formatter.Format(violations)
-	assert.Regexp(t, `21:minphony:Missing required phony target "all"`, out.String())
-	assert.Regexp(t, `21:minphony:Missing required phony target "test"`, out.String())
-	assert.Regexp(t, `16:phonydeclared:Target "all" should be declared PHONY.`, out.String())
+	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Missing required phony target "all"`, out.String())
+	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Missing required phony target "test"`, out.String())
+	assert.Regexp(t, `../fixtures/missing_phony.make:16:phonydeclared:Target "all" should be declared PHONY.`, out.String())
 }
 
 func TestCustomFormatterNewMethod(t *testing.T) {
-	_, err := NewCustomFormatter("{{.LineNumber}}:{{.Rule}}:{{.Violation}}")
+	_, err := NewCustomFormatter("{{.FileName}}:{{.LineNumber}}:{{.Rule}}:{{.Violation}}")
 
 	assert.Equal(t, nil, err)
 }

--- a/formatters/default.go
+++ b/formatters/default.go
@@ -26,12 +26,13 @@ func (f *DefaultFormatter) Format(violations rules.RuleViolationList) {
 	for idx, val := range violations {
 		data[idx] = []string{val.Rule,
 			val.Violation,
+			val.FileName,
 			strconv.Itoa(val.LineNumber)}
 	}
 
 	table := tablewriter.NewWriter(f.out)
 
-	table.SetHeader([]string{"Rule", "Description", "Line Number"})
+	table.SetHeader([]string{"Rule", "Description", "File Name", "Line Number"})
 
 	table.SetCenterSeparator(" ")
 	table.SetColumnSeparator(" ")

--- a/formatters/default_test.go
+++ b/formatters/default_test.go
@@ -19,7 +19,7 @@ func TestDefaultFormatter(t *testing.T) {
 	violations := validator.Validate(makefile, &config.Config{})
 	formatter.Format(violations)
 
-	assert.Regexp(t, `\s+RULE\s+DESCRIPTION\s+LINE NUMBER\s+`, out.String())
+	assert.Regexp(t, `\s+RULE\s+DESCRIPTION\s+FILE NAME\s+LINE NUMBER\s+`, out.String())
 	assert.Regexp(t, `phonydeclared\s+Target "all" should be.+\s+16`, out.String())
 	assert.Regexp(t, `\s+declared PHONY`, out.String())
 }

--- a/man/man1/checkmake.1.md
+++ b/man/man1/checkmake.1.md
@@ -9,11 +9,11 @@ date: REPLACE_DATE
 
 # SYNOPSIS
 
-**checkmake** \[options\] makefile
+**checkmake** \[options\] makefile ...
 
 # DESCRIPTION
 `checkmake` is an experimental linter for Makefiles. It allows for a set of
-configurable rules being run against a Makefile.
+configurable rules being run against a Makefile or a set of `\*.mk` files.
 
 # OPTIONS
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -15,6 +15,7 @@ import (
 
 // Makefile provides a data structure to describe a parsed Makefile
 type Makefile struct {
+	FileName  string
 	Rules     RuleList
 	Variables VariableList
 }
@@ -56,6 +57,7 @@ var (
 // know how to deal with individual lines.
 func Parse(filepath string) (ret Makefile, err error) {
 
+	ret.FileName = filepath
 	var scanner *MakefileScanner
 	scanner, err = NewMakefileScanner(filepath)
 	if err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -25,6 +25,7 @@ type Rule struct {
 	Target       string
 	Dependencies []string
 	Body         []string
+	FileName     string
 	LineNumber   int
 }
 
@@ -37,6 +38,7 @@ type Variable struct {
 	SimplyExpanded  bool
 	Assignment      string
 	SpecialVariable bool
+	FileName        string
 	LineNumber      int
 }
 
@@ -75,6 +77,7 @@ func Parse(filepath string) (ret Makefile, err error) {
 					Name:            strings.TrimSpace(matches[1]),
 					Assignment:      strings.TrimSpace(matches[2]),
 					SpecialVariable: true,
+					FileName:        filepath,
 					LineNumber:      scanner.LineNumber}
 				ret.Variables = append(ret.Variables, specialVar)
 			}
@@ -149,12 +152,14 @@ func parseRuleOrVariable(scanner *MakefileScanner) (ret interface{}, err error) 
 			Target:       strings.TrimSpace(matches[1]),
 			Dependencies: filteredDeps,
 			Body:         ruleBody,
+			FileName:     scanner.FileHandle.Name(),
 			LineNumber:   beginLineNumber}
 	} else if matches := reFindSimpleVariable.FindStringSubmatch(line); matches != nil {
 		ret = Variable{
 			Name:           strings.TrimSpace(matches[1]),
 			Assignment:     strings.TrimSpace(matches[2]),
 			SimplyExpanded: true,
+			FileName:       scanner.FileHandle.Name(),
 			LineNumber:     scanner.LineNumber}
 		scanner.Scan()
 	} else if matches := reFindExpandedVariable.FindStringSubmatch(line); matches != nil {
@@ -162,6 +167,7 @@ func parseRuleOrVariable(scanner *MakefileScanner) (ret interface{}, err error) 
 			Name:           strings.TrimSpace(matches[1]),
 			Assignment:     strings.TrimSpace(matches[2]),
 			SimplyExpanded: false,
+			FileName:       scanner.FileHandle.Name(),
 			LineNumber:     scanner.LineNumber}
 		scanner.Scan()
 	} else {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -16,34 +16,42 @@ func TestParseSimpleMakefile(t *testing.T) {
 	assert.Equal(t, len(ret.Variables), 4)
 	assert.Equal(t, ret.Rules[0].Target, "clean")
 	assert.Equal(t, ret.Rules[0].Body, []string{"rm bar", "rm foo"})
+	assert.Equal(t, ret.Rules[0].FileName, "../fixtures/simple.make")
 
 	assert.Equal(t, ret.Rules[1].Target, "foo")
 	assert.Equal(t, ret.Rules[1].Body, []string{"touch foo"})
 	assert.Equal(t, ret.Rules[1].Dependencies, []string{"bar"})
+	assert.Equal(t, ret.Rules[1].FileName, "../fixtures/simple.make")
 
 	assert.Equal(t, ret.Rules[2].Target, "bar")
 	assert.Equal(t, ret.Rules[2].Body, []string{"touch bar"})
+	assert.Equal(t, ret.Rules[2].FileName, "../fixtures/simple.make")
 
 	assert.Equal(t, ret.Rules[3].Target, "all")
 	assert.Equal(t, ret.Rules[3].Dependencies, []string{"foo"})
+	assert.Equal(t, ret.Rules[3].FileName, "../fixtures/simple.make")
 
 	assert.Equal(t, ret.Variables[0].Name, "expanded")
 	assert.Equal(t, ret.Variables[0].Assignment, "\"$(simple)\"")
 	assert.Equal(t, ret.Variables[0].SimplyExpanded, false)
 	assert.Equal(t, ret.Variables[0].SpecialVariable, false)
+	assert.Equal(t, ret.Variables[0].FileName, "../fixtures/simple.make")
 
 	assert.Equal(t, ret.Variables[1].Name, "simple")
 	assert.Equal(t, ret.Variables[1].Assignment, "\"foo\"")
 	assert.Equal(t, ret.Variables[1].SimplyExpanded, true)
 	assert.Equal(t, ret.Variables[1].SpecialVariable, false)
+	assert.Equal(t, ret.Variables[1].FileName, "../fixtures/simple.make")
 
 	assert.Equal(t, ret.Variables[2].Name, "PHONY")
 	assert.Equal(t, ret.Variables[2].Assignment, "all clean test")
 	assert.Equal(t, ret.Variables[2].SimplyExpanded, false)
 	assert.Equal(t, ret.Variables[2].SpecialVariable, true)
+	assert.Equal(t, ret.Variables[2].FileName, "../fixtures/simple.make")
 
 	assert.Equal(t, ret.Variables[3].Name, "DEFAULT_GOAL")
 	assert.Equal(t, ret.Variables[3].Assignment, "all")
 	assert.Equal(t, ret.Variables[3].SimplyExpanded, false)
 	assert.Equal(t, ret.Variables[3].SpecialVariable, true)
+	assert.Equal(t, ret.Variables[3].FileName, "../fixtures/simple.make")
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -11,6 +11,7 @@ func TestParseSimpleMakefile(t *testing.T) {
 	ret, err := Parse("../fixtures/simple.make")
 
 	assert.Equal(t, err, nil)
+	assert.Equal(t, ret.FileName, "../fixtures/simple.make")
 	assert.Equal(t, len(ret.Rules), 5)
 	assert.Equal(t, len(ret.Variables), 4)
 	assert.Equal(t, ret.Rules[0].Target, "clean")

--- a/rules/maxbodylength/maxbodylength.go
+++ b/rules/maxbodylength/maxbodylength.go
@@ -51,6 +51,7 @@ func (m *MaxBodyLength) Run(makefile parser.Makefile, config rules.RuleConfig) r
 			ret = append(ret, rules.RuleViolation{
 				Rule:       "maxbodylength",
 				Violation:  fmt.Sprintf(vT, rule.Target, maxBodyLength, len(rule.Body)),
+				FileName:   makefile.FileName,
 				LineNumber: rule.LineNumber,
 			})
 		}

--- a/rules/maxbodylength/maxbodylength_test.go
+++ b/rules/maxbodylength/maxbodylength_test.go
@@ -11,6 +11,7 @@ import (
 func TestFooIsTooLong(t *testing.T) {
 
 	makefile := parser.Makefile{
+		FileName: "maxbodylength.mk",
 		Rules: []parser.Rule{parser.Rule{
 			Target: "foo",
 			Body: []string{"echo 'foo'",
@@ -32,11 +33,13 @@ func TestFooIsTooLong(t *testing.T) {
 		rule.Description())
 	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 5 (7).", ret[0].Violation)
 	assert.Equal(t, 1, ret[0].LineNumber)
+	assert.Equal(t, "maxbodylength.mk", ret[0].FileName)
 }
 
 func TestFooIsTooLongWithConfig(t *testing.T) {
 
 	makefile := parser.Makefile{
+		FileName: "maxbodylength.mk",
 		Rules: []parser.Rule{parser.Rule{
 			Target: "foo",
 			Body: []string{"echo 'foo'",
@@ -58,4 +61,5 @@ func TestFooIsTooLongWithConfig(t *testing.T) {
 		rule.Description())
 	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 3 (4).", ret[0].Violation)
 	assert.Equal(t, 1, ret[0].LineNumber)
+	assert.Equal(t, "maxbodylength.mk", ret[0].FileName)
 }

--- a/rules/minphony/minphony.go
+++ b/rules/minphony/minphony.go
@@ -58,6 +58,7 @@ func (r *MinPhony) Run(makefile parser.Makefile, _ rules.RuleConfig) rules.RuleV
 			ret = append(ret, rules.RuleViolation{
 				Rule:       "minphony",
 				Violation:  fmt.Sprintf("Missing required phony target %q", reqRule),
+				FileName:   makefile.FileName,
 				LineNumber: ruleLineNumber,
 			})
 		}

--- a/rules/minphony/minphony_test.go
+++ b/rules/minphony/minphony_test.go
@@ -14,6 +14,7 @@ var mpRunTests = []struct {
 }{
 	{
 		mf: parser.Makefile{
+			FileName: "green-eggs.mk",
 			Rules: parser.RuleList{
 				{Target: "green-eggs"},
 				{Target: "ham"},
@@ -26,22 +27,26 @@ var mpRunTests = []struct {
 			rules.RuleViolation{
 				Rule:       "minphony",
 				Violation:  "Missing required phony target \"kleen\"",
+				FileName: "green-eggs.mk",
 				LineNumber: -1,
 			},
 			rules.RuleViolation{
 				Rule:       "minphony",
 				Violation:  "Missing required phony target \"awl\"",
+				FileName: "green-eggs.mk",
 				LineNumber: -1,
 			},
 			rules.RuleViolation{
 				Rule:       "minphony",
 				Violation:  "Missing required phony target \"toast\"",
+				FileName: "green-eggs.mk",
 				LineNumber: -1,
 			},
 		},
 	},
 	{
 		mf: parser.Makefile{
+			FileName: "kleen.mk",
 			Rules: parser.RuleList{
 				{Target: "awl"},
 				{Target: "distkleen"},
@@ -55,6 +60,7 @@ var mpRunTests = []struct {
 			rules.RuleViolation{
 				Rule:       "minphony",
 				Violation:  "Missing required phony target \"toast\"",
+				FileName:   "kleen.mk",
 				LineNumber: -1,
 			},
 		},

--- a/rules/phonydeclared/phonydeclared.go
+++ b/rules/phonydeclared/phonydeclared.go
@@ -48,6 +48,7 @@ func (r *Phonydeclared) Run(makefile parser.Makefile, config rules.RuleConfig) r
 			ret = append(ret, rules.RuleViolation{
 				Rule:       "phonydeclared",
 				Violation:  fmt.Sprintf("Target %q should be declared PHONY.", rule.Target),
+				FileName:   makefile.FileName,
 				LineNumber: rule.LineNumber,
 			})
 		}

--- a/rules/phonydeclared/phonydeclared_test.go
+++ b/rules/phonydeclared/phonydeclared_test.go
@@ -11,6 +11,7 @@ import (
 func TestAllTargetsArePhony(t *testing.T) {
 
 	makefile := parser.Makefile{
+		FileName:  "phony-declared-all-phony.mk",
 		Variables: []parser.Variable{parser.Variable{
 			Name:       "PHONY",
 			Assignment: "all clean"}},
@@ -29,6 +30,7 @@ func TestAllTargetsArePhony(t *testing.T) {
 func TestMissingOnePhonyTarget(t *testing.T) {
 
 	makefile := parser.Makefile{
+		FileName:  "phony-declared-missing-one-phony.mk",
 		Variables: []parser.Variable{parser.Variable{
 			Name:       "PHONY",
 			Assignment: "all"}},
@@ -42,4 +44,7 @@ func TestMissingOnePhonyTarget(t *testing.T) {
 
 	assert.Equal(t, len(ret), 1)
 
+	for i := range ret {
+		assert.Equal(t, "phony-declared-missing-one-phony.mk", ret[i].FileName)
+	}
 }

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -16,6 +16,7 @@ type Rule interface {
 type RuleViolation struct {
 	Rule       string
 	Violation  string
+	FileName   string
 	LineNumber int
 }
 

--- a/rules/timestampexpanded/timestampexpanded.go
+++ b/rules/timestampexpanded/timestampexpanded.go
@@ -46,6 +46,7 @@ func (r *Timestampexpanded) Run(makefile parser.Makefile, config rules.RuleConfi
 			ret = append(ret, rules.RuleViolation{
 				Rule:       "timestampexpanded",
 				Violation:  fmt.Sprintf(vT, variable.Name),
+				FileName:   makefile.FileName,
 				LineNumber: variable.LineNumber,
 			})
 		}

--- a/rules/timestampexpanded/timestampexpanded_test.go
+++ b/rules/timestampexpanded/timestampexpanded_test.go
@@ -11,6 +11,7 @@ import (
 func TestVersionIsNotSimplyExpanded(t *testing.T) {
 
 	makefile := parser.Makefile{
+		FileName:  "timestamp-expanded.mk",
 		Variables: []parser.Variable{parser.Variable{
 			Name:           "BUILDTIME",
 			Assignment:     "$(shell date -u +\"%Y-%m-%dT%H:%M:%SZ\")",
@@ -24,11 +25,15 @@ func TestVersionIsNotSimplyExpanded(t *testing.T) {
 	assert.Equal(t, 1, len(ret))
 	assert.Equal(t, "timestamp variables should be simply expanded",
 		rule.Description())
+	for i := range ret {
+		assert.Equal(t, "timestamp-expanded.mk", ret[i].FileName)
+	}
 }
 
 func TestVersionIsSimplyExpanded(t *testing.T) {
 
 	makefile := parser.Makefile{
+		FileName:  "timestamp-simply-expanded.mk",
 		Variables: []parser.Variable{parser.Variable{
 			Name:           "BUILDTIME",
 			Assignment:     "$(shell date -u +\"%Y-%m-%dT%H:%M:%SZ\")",


### PR DESCRIPTION
## Description

As a follow-up to #69, this PR adds support for passing multiple `Makefile` / `*.mk` paths
as command-line arguments, just like how `pre-commit run --all-files` will execute `checkmake` when a repo contains multiple `*.mk` files.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
  - [Tests passing on my fork here][1]
- [x] Description of proposed change
  - See above
- [x] Documentation (README, docs/, man pages) is updated
  - See `README.md`, `man/man1/checkmake.1.md` file diffs
- [x] Existing issue is referenced if there is one
  - Follow-up to #69 
  - Avoids usage errors when running `checkmate` via `pre-commit run --all-files`
- [x] Unit tests for the proposed change
  - See `*_test.go` file diffs

[1]: https://github.com/trinitronx/checkmake/runs/6205167371?check_suite_focus=true#step:5:1
