### PR TITLE
Reduces files to the built-in makefile type for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,9 +3,4 @@
     entry: checkmake
     language: golang
     pass_filenames: true
-    files: |
-        (?x)^(
-            (GNU)?[Mm]akefile|
-            .*\.mk|
-            .*\.make
-        )$
+    types: [makefile]


### PR DESCRIPTION
As nudged [here][1], but this won't be fully effective until https://github.com/pre-commit/identify/pull/353 is merged.

I think this is safe to merge before 353 because so few people use `*.make`... I think I've seen it maybe a few times in 20 years. Also, this hook is so new to checkmake that probably not that many people are using it yet.

[1]: https://github.com/pre-commit/pre-commit.com/pull/756#issuecomment-1356462222

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [X] CI passes
- [X] Description of proposed change
- [X] Documentation (README, docs/, man pages) is updated
- [X] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
