### PR TITLE
support checkmake.ini overriding of minphony required targets

### DIFF
--- a/rules/minphony/minphony.go
+++ b/rules/minphony/minphony.go
@@ -38,8 +38,12 @@ func (r *MinPhony) Description() string {
 }
 
 // Run executes the rule logic
-func (r *MinPhony) Run(makefile parser.Makefile, _ rules.RuleConfig) rules.RuleViolationList {
+func (r *MinPhony) Run(makefile parser.Makefile, config rules.RuleConfig) rules.RuleViolationList {
 	ret := rules.RuleViolationList{}
+
+	if confMinphony, ok := config["required"]; ok {
+		r.required = strings.Split(confMinphony, " ")
+	}
 
 	ruleIndex := make(map[string]bool)
 	ruleLineNumber := 0


### PR DESCRIPTION
Fixed the minphony implementation to actually support overriding from checkmake.ini file.

Long term, there is some refactoring to do in the data models and overriding logic, such as for maxbodylength and other rules. Specifically, Go tags in the models should do 90% of the work for us. And the INI library we're using already supports this:

https://ini.unknwon.io/docs/advanced/map_and_reflect

Note: The INI library appears to split by comma-with-space (unknown sensitivity to lack of space), while *this* patch splits by a single space delimiter.

Any special parsing/rendering requirements on top of that automatic marshaling, can be done by overriding INI marshaling methods on the data models.

But refactoring's for another day. I just want the app to work.

This fix would close #86.

If the fix is acceptable, then I would love to see this included in a new release version soon, for the benefit of us DevOps who prefer to use non-HEAD versions of our tools :)