### PR TITLE
Adds a system-provided checkmake hook for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ exclude: |
     )$
 repos:
 -   repo: https://github.com/mrtazz/checkmake.git
-    rev: 0.2.2
+    rev: main
     hooks:
     - id: checkmake
       exclude: |

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,9 @@
     language: golang
     pass_filenames: true
     types: [makefile]
+-   id: checkmake-system
+    name: Makefile linter/analyzer
+    entry: checkmake
+    language: system
+    types: [makefile]
+    pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -64,16 +64,35 @@ repos. Simply add a `.pre-commit-config.yaml` to your repo's top-level directory
 ```yaml
 repos:
 -   repo: https://github.com/mrtazz/checkmake.git
+    # Or another commit hash or version
     rev: 0.2.2
     hooks:
+    # Use this hook to let pre-commit build checkmake in its sandbox
     -   id: checkmake
+    # OR Use this hook to use a pre-installed checkmark executable
+    # -   id: checkmake-system
 ```
 
-Then, run `pre-commit` as usual. For example:
+There are two hooks available:
+
+- `checkmake` (Recommended)
+
+   pre-commit will set up a Go environment from scratch to compile and run checkmake.
+   See the [pre-commit `golang` plugin docs](https://pre-commit.com/#golang) for more information.
+
+- `checkmake-system`
+
+   pre-commit will look for `checkmake` on your `PATH`.
+   This hook requires you to install `checkmake` separately, e.g. with your package manager or [a prebuilt binary release](https://github.com/mrtazz/checkmake/releases).
+   Only recommended if it's permissible to require all repository users install `checkmake` manually.
+
+Then, run `pre-commit` as usual as a part of `git commit` or explicitly, for example:
 
 ```sh
 pre-commit run --all-files
 ```
+
+### pre-commit in GitHub Actions
 
 You may also choose to run this as a GitHub Actions workflow. To do this, add a
 `.github/workflows/pre-commit.yml` workflow to your repo:


### PR DESCRIPTION
[Problems with pre-commit's invocation of `go install`][pc-gh2722] had me wanting more options for how to run hooks in case the automated installation fails. Since checkmake is available in at least Homebrew, it'd be nice to have a hook that can use a checkmake executable already installed in the system PATH.

[pc-gh2722]: https://github.com/pre-commit/pre-commit/issues/2722

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [x] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
