### PR TITLE
Append new line between records when using custom --format

### DIFF
--- a/formatters/custom.go
+++ b/formatters/custom.go
@@ -35,6 +35,7 @@ func (f *CustomFormatter) Format(violations rules.RuleViolationList) {
 
 	for _, val := range violations {
 		err := f.template.Execute(f.out, val)
+		f.out.Write([]byte("\n"))
 		if err != nil {
 			logger.Error(err.Error())
 		}

--- a/formatters/custom_test.go
+++ b/formatters/custom_test.go
@@ -2,6 +2,7 @@ package formatters
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -24,6 +25,7 @@ func TestCustomFormatter(t *testing.T) {
 	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Missing required phony target "all"`, out.String())
 	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Missing required phony target "test"`, out.String())
 	assert.Regexp(t, `../fixtures/missing_phony.make:16:phonydeclared:Target "all" should be declared PHONY.`, out.String())
+	assert.Equal(t, strings.Count(out.String(), "\n"), 3)
 }
 
 func TestCustomFormatterNewMethod(t *testing.T) {


### PR DESCRIPTION
According to the documentation, when using the --format option, each error report must end with a new line, which is not the case.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ X] Description of proposed change
- [ X] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ X] Unit tests for the proposed change
