### PR TITLE
Build darwin.arm64 binaries

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -70,6 +70,7 @@ jobs:
         BUILD_GOARCH=amd64 BUILD_GOOS=freebsd make build-standalone
         BUILD_GOARCH=amd64 BUILD_GOOS=linux   make build-standalone
         BUILD_GOARCH=amd64 BUILD_GOOS=darwin  make build-standalone
+        BUILD_GOARCH=arm64 BUILD_GOOS=darwin  make build-standalone
 
     - name: create release
       run: make github-release


### PR DESCRIPTION
This PR adds support for building `darwin.arm64` binaries.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [-] Documentation (README, docs/, man pages) is updated
- [-] Existing issue is referenced if there is one
- [-] Unit tests for the proposed change
