### PR TITLE
Optimize Dockerfile to use `apk add` with `--no-cache`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make binaries
 RUN make test
 
 FROM alpine:3.11
-RUN apk add make
+RUN apk add --no-cache make
 USER nobody
 
 COPY --from=builder /go/src/github.com/mrtazz/checkmake/checkmake /


### PR DESCRIPTION
Make `apk add` to use `--no-cache` for package installation. This will prevent the package index from being cached and reduce the image size.


## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
