### PR TITLE
add ~/checkmake.ini as global fallback config

### DIFF
--- a/cmd/checkmake/main.go
+++ b/cmd/checkmake/main.go
@@ -74,6 +74,12 @@ func parseArgsAndGetFormatter(args map[string]interface{}) (formatters.Formatter
 
 	if args["--config"] != nil {
 		configPath = args["--config"].(string)
+	} else {
+		_, err := os.Stat(configPath);
+		if os.IsNotExist(err) {
+			home := os.Getenv("HOME")
+			configPath = home + "/checkmake.ini"
+		}
 	}
 
 	cfg, cfgError := config.NewConfigFromFile(configPath)

--- a/man/man1/checkmake.1.md
+++ b/man/man1/checkmake.1.md
@@ -36,12 +36,14 @@ configurable rules being run against a Makefile or a set of `\*.mk` files.
 :    List registered rules
 
 # CONFIGURATION
-By default checkmake looks for a `checkmake.ini` file in the same folder it's
-executed in. This can be overridden by passing the `--config=` argument
-pointing it to a different configuration file. With the configuration file
-the `[default]` section is for checkmake itself while sections named after the
-rule names are passed to the rules as their configuration. All keys/values are
-hereby treated as strings and passed to the rule in a string/string map.
+By default checkmake looks for a `checkmake.ini` file in the same
+folder it's executed in, and then as fallback in `~/checkmake.ini`.
+This can be overridden by passing the `--config=` argument pointing it
+to a different configuration file. With the configuration file the
+`[default]` section is for checkmake itself while sections named after
+the rule names are passed to the rules as their configuration. All
+keys/values are hereby treated as strings and passed to the rule in a
+string/string map.
 
 The following configuration options for checkmake itself are supported within
 the `default` section:


### PR DESCRIPTION
Didn't test on windows. Not sure about their HOME env there. Might be global "/checkmake.ini" there then.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [x] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
