### PR TITLE
Improve the maxbodylength  rule description

### DIFF
--- a/rules/maxbodylength/maxbodylength.go
+++ b/rules/maxbodylength/maxbodylength.go
@@ -33,7 +33,7 @@ func (m *MaxBodyLength) Name() string {
 
 // Description returns the description of the rule
 func (m *MaxBodyLength) Description() string {
-	return "Target bodies should be kept simple and short."
+	return fmt.Sprintf("Target bodies should be kept simple and short (no more than %d lines).", maxBodyLength)
 }
 
 // Run executes the rule logic

--- a/rules/maxbodylength/maxbodylength.go
+++ b/rules/maxbodylength/maxbodylength.go
@@ -23,7 +23,7 @@ type MaxBodyLength struct {
 }
 
 var (
-	vT = "Target body for %q exceeds allowed length of %d (%d)."
+	vT = "Target body for %q exceeds allowed length of %d lines (%d)."
 )
 
 // Name returns the name of the rule

--- a/rules/maxbodylength/maxbodylength_test.go
+++ b/rules/maxbodylength/maxbodylength_test.go
@@ -29,7 +29,7 @@ func TestFooIsTooLong(t *testing.T) {
 	ret := rule.Run(makefile, rules.RuleConfig{})
 
 	assert.Equal(t, 1, len(ret))
-	assert.Equal(t, "Target bodies should be kept simple and short.",
+	assert.Equal(t, "Target bodies should be kept simple and short (no more than 5 lines).",
 		rule.Description())
 	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 5 lines (7).", ret[0].Violation)
 	assert.Equal(t, 1, ret[0].LineNumber)
@@ -57,7 +57,7 @@ func TestFooIsTooLongWithConfig(t *testing.T) {
 	ret := rule.Run(makefile, cfg)
 
 	assert.Equal(t, 1, len(ret))
-	assert.Equal(t, "Target bodies should be kept simple and short.",
+	assert.Equal(t, "Target bodies should be kept simple and short (no more than 3 lines).",
 		rule.Description())
 	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 3 lines (4).", ret[0].Violation)
 	assert.Equal(t, 1, ret[0].LineNumber)

--- a/rules/maxbodylength/maxbodylength_test.go
+++ b/rules/maxbodylength/maxbodylength_test.go
@@ -31,7 +31,7 @@ func TestFooIsTooLong(t *testing.T) {
 	assert.Equal(t, 1, len(ret))
 	assert.Equal(t, "Target bodies should be kept simple and short.",
 		rule.Description())
-	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 5 (7).", ret[0].Violation)
+	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 5 lines (7).", ret[0].Violation)
 	assert.Equal(t, 1, ret[0].LineNumber)
 	assert.Equal(t, "maxbodylength.mk", ret[0].FileName)
 }
@@ -59,7 +59,7 @@ func TestFooIsTooLongWithConfig(t *testing.T) {
 	assert.Equal(t, 1, len(ret))
 	assert.Equal(t, "Target bodies should be kept simple and short.",
 		rule.Description())
-	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 3 (4).", ret[0].Violation)
+	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 3 lines (4).", ret[0].Violation)
 	assert.Equal(t, 1, ret[0].LineNumber)
 	assert.Equal(t, "maxbodylength.mk", ret[0].FileName)
 }


### PR DESCRIPTION
**Description of changes:** 

    The description of the maxbodylength rule shown with `checkmake --list-rules` 
    was not very specific:

```console

      maxbodylength       Target bodies should be kept
                          simple and short.

```
    
    This change adds the detail that length refers to a certain maximum
    number of lines:
```console 
 
      maxbodylength       Target bodies should be kept
                          simple and short (no more than
                          5 lines).

```

This is a follow-up to PR #109 depending on it)  and a partial solution to issue #108 


## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [x] Existing issue is referenced if there is one
- [x] Unit tests for the proposed change
