### PR TITLE
rules: expand  description of the minphony rule

### DIFF
--- a/cmd/checkmake/main_test.go
+++ b/cmd/checkmake/main_test.go
@@ -34,7 +34,7 @@ func TestListRules(t *testing.T) {
 	assert.Regexp(t, `phonydeclared\s+Every target without a body`, out.String())
 	assert.Regexp(t, `\s+needs to be marked PHONY`, out.String())
 
-	assert.Regexp(t, `minphony\s+Minimum required phony targets`, out.String())
-	assert.Regexp(t, `\s+must be present`, out.String())
+	assert.Regexp(t, `minphony\s+Minimum required phony`, out.String())
+	assert.Regexp(t, `\s+targets must be present(.*)`, out.String())
 
 }

--- a/rules/minphony/minphony.go
+++ b/rules/minphony/minphony.go
@@ -34,7 +34,7 @@ func (r *MinPhony) Name() string {
 
 // Description returns the description of the rule
 func (r *MinPhony) Description() string {
-	return "Minimum required phony targets must be present"
+	return fmt.Sprintf("Minimum required phony targets must be present (%s)", strings.Join(r.required, ","))
 }
 
 // Run executes the rule logic

--- a/rules/minphony/minphony_test.go
+++ b/rules/minphony/minphony_test.go
@@ -1,6 +1,8 @@
 package minphony
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mrtazz/checkmake/parser"
@@ -72,7 +74,9 @@ func TestMinPhony_new(t *testing.T) {
 
 	assert.Equal(t, []string{"oh", "hai"}, mp.required)
 	assert.Equal(t, "minphony", mp.Name())
-	assert.Equal(t, "Minimum required phony targets must be present", mp.Description())
+	expected_desc := fmt.Sprintf("Minimum required phony targets must be present (%s)", strings.Join(mp.required, ","))
+
+	assert.Equal(t, expected_desc, mp.Description())
 }
 
 func TestMinPhony_Run(t *testing.T) {


### PR DESCRIPTION
**Description of changes:** 
This expand the description of the minphony rule to include listing the required phony targets.

With this change, the default output of --list-rules looks like this:

```console
$ checkmake --list-rules
...
        NAME                   DESCRIPTION
  minphony            Minimum required phony
                      targets must be present
                      (all,clean,test)
$
```

after PR #111,  this is a second part of addressing issue #108 


## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [x] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
